### PR TITLE
Add web socket custom headers support in nats py client

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -33,6 +33,8 @@ from secrets import token_hex
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import ParseResult, urlparse
 
+from requests import options
+
 try:
     from fast_mail_parser import parse_email
 except ImportError:
@@ -358,6 +360,7 @@ class Client:
         inbox_prefix: Union[str, bytes] = DEFAULT_INBOX_PREFIX,
         pending_size: int = DEFAULT_PENDING_SIZE,
         flush_timeout: Optional[float] = None,
+        ws_connection_headers: Optional[Dict[str,List[str]]] = None,
     ) -> None:
         """
         Establishes a connection to NATS.
@@ -495,6 +498,7 @@ class Client:
         self.options["connect_timeout"] = connect_timeout
         self.options["drain_timeout"] = drain_timeout
         self.options["tls_handshake_first"] = tls_handshake_first
+        self.options["ws_connection_headers"] = ws_connection_headers
 
         if tls:
             self.options["tls"] = tls
@@ -1380,7 +1384,7 @@ class Client:
                 s.last_attempt = time.monotonic()
                 if not self._transport:
                     if s.uri.scheme in ("ws", "wss"):
-                        self._transport = WebSocketTransport()
+                        self._transport = WebSocketTransport(ws_headers=self.options["ws_connection_headers"])
                     else:
                         # use TcpTransport as a fallback
                         self._transport = TcpTransport()

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -33,8 +33,6 @@ from secrets import token_hex
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import ParseResult, urlparse
 
-from requests import options
-
 try:
     from fast_mail_parser import parse_email
 except ImportError:

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -358,7 +358,7 @@ class Client:
         inbox_prefix: Union[str, bytes] = DEFAULT_INBOX_PREFIX,
         pending_size: int = DEFAULT_PENDING_SIZE,
         flush_timeout: Optional[float] = None,
-        ws_connection_headers: Optional[Dict[str,List[str]]] = None,
+        ws_connection_headers: Optional[Dict[str, List[str]]] = None,
     ) -> None:
         """
         Establishes a connection to NATS.

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -281,6 +281,9 @@ class WebSocketTransport(Transport):
             return None
         md: multidict.CIMultiDict[str] = multidict.CIMultiDict()
         for name, values in self._ws_headers.items():
-            for v in values:
-                md.add(name, v)
+            if isinstance(values, list):
+                for v in values:
+                    md.add(name, v)
+            elif isinstance(values, str):
+                    md.add(name, values)
         return md

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -11,7 +11,7 @@ try:
     import multidict
 except ImportError:
     aiohttp = None  # type: ignore[assignment]
-    multidict = None # type: ignore[assignment]
+    multidict = None  # type: ignore[assignment]
 
 from nats.errors import ProtocolError
 
@@ -194,7 +194,7 @@ class TcpTransport(Transport):
 
 class WebSocketTransport(Transport):
 
-    def __init__(self,ws_headers: Optional[Dict[str,List[str]]] =None):
+    def __init__(self, ws_headers: Optional[Dict[str, List[str]]] = None):
         if not aiohttp:
             raise ImportError(
                 "Could not import aiohttp transport, please install it with `pip install aiohttp`"
@@ -212,7 +212,7 @@ class WebSocketTransport(Transport):
         headers = self._get_custom_headers()
         # for websocket library, the uri must contain the scheme already
         self._ws = await self._client.ws_connect(
-            uri.geturl(), timeout=connect_timeout, headers=headers,
+            uri.geturl(), timeout=connect_timeout, headers=headers
         )
         self._using_tls = False
 
@@ -285,5 +285,5 @@ class WebSocketTransport(Transport):
                 for v in values:
                     md.add(name, v)
             elif isinstance(values, str):
-                    md.add(name, values)
+                md.add(name, values)
         return md

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import abc
 import asyncio
 import ssl
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 from urllib.parse import ParseResult
 
 try:
     import aiohttp
+    import multidict
 except ImportError:
     aiohttp = None  # type: ignore[assignment]
+    multidict = None # type: ignore[assignment]
 
 from nats.errors import ProtocolError
 
@@ -192,7 +194,7 @@ class TcpTransport(Transport):
 
 class WebSocketTransport(Transport):
 
-    def __init__(self):
+    def __init__(self,ws_headers: Optional[Dict[str,List[str]]] =None):
         if not aiohttp:
             raise ImportError(
                 "Could not import aiohttp transport, please install it with `pip install aiohttp`"
@@ -202,13 +204,15 @@ class WebSocketTransport(Transport):
         self._pending = asyncio.Queue()
         self._close_task = asyncio.Future()
         self._using_tls: Optional[bool] = None
+        self._ws_headers = ws_headers
 
     async def connect(
         self, uri: ParseResult, buffer_size: int, connect_timeout: int
     ):
+        headers = self._get_custom_headers()
         # for websocket library, the uri must contain the scheme already
         self._ws = await self._client.ws_connect(
-            uri.geturl(), timeout=connect_timeout
+            uri.geturl(), timeout=connect_timeout, headers=headers,
         )
         self._using_tls = False
 
@@ -224,10 +228,12 @@ class WebSocketTransport(Transport):
                 return
             raise ProtocolError("ws: cannot upgrade to TLS")
 
+        headers = self._get_custom_headers()
         self._ws = await self._client.ws_connect(
             uri if isinstance(uri, str) else uri.geturl(),
             ssl=ssl_context,
             timeout=connect_timeout,
+            headers=headers,
         )
         self._using_tls = True
 
@@ -269,3 +275,12 @@ class WebSocketTransport(Transport):
 
     def __bool__(self):
         return bool(self._client)
+
+    def _get_custom_headers(self):
+        if self._ws_headers is None:
+            return None
+        md: multidict.CIMultiDict[str] = multidict.CIMultiDict()
+        for name, values in self._ws_headers.items():
+            for v in values:
+                md.add(name, v)
+        return md

--- a/tests/test_client_websocket.py
+++ b/tests/test_client_websocket.py
@@ -198,6 +198,114 @@ class WebSocketTest(SingleWebSocketServerTestCase):
         # Should not fail closing while disconnected.
         await nc.close()
 
+    @async_test
+    async def test_with_static_headers(self):
+        if not aiohttp_installed:
+            pytest.skip("aiohttp not installed")
+
+        custom_headers = {
+            "Authorization": ["Bearer RandomToken"],
+            "X-Client-ID": ["test-client-123"],
+            "X-Custom-Header": ["custom-value"],
+            "Accept": ["application/json", "text/plain", "application/msgpack"],
+            "X-Feature-Flags": ["feature-a", "feature-b", "feature-c"],
+            "X-Capabilities": ["streaming", "compression", "batching"]
+        }
+
+        nc = await nats.connect(
+            "ws://localhost:8080",
+            ws_connection_headers=custom_headers
+        )
+
+        # Test basic pub/sub functionality to ensure connection works
+        sub = await nc.subscribe("foo")
+        await nc.flush()
+
+        # Create test messages
+        msgs = []
+        for i in range(10):
+            msg = b'A' * 100  # 100 bytes of 'A'
+            msgs.append(msg)
+
+        # Publish messages
+        for i, msg in enumerate(msgs):
+            await nc.publish("foo", msg)
+            # Ensure message content is not modified
+            assert msg == msgs[i], f"User content was changed during publish"
+
+        # Receive and verify messages
+        for i in range(len(msgs)):
+            msg = await sub.next_msg(timeout=1.0)
+            assert msg.data == msgs[i], f"Expected message {i}: {msgs[i]}, got {msg.data}"
+
+        await nc.close()
+
+    @async_test
+    async def test_ws_headers_with_reconnect(self):
+        """Test that headers persist across reconnections"""
+        if not aiohttp_installed:
+            pytest.skip("aiohttp not installed")
+
+        reconnect_count = 0
+        reconnected = asyncio.Future()
+
+        async def reconnected_cb():
+            nonlocal reconnect_count
+            reconnect_count += 1
+            if not reconnected.done():
+                reconnected.set_result(True)
+
+        # Connect with custom headers
+        custom_headers = {
+            "X-Persistent-Session": ["session-12345"],
+            "Authorization": ["Bearer ReconnectToken"]
+        }
+
+        nc = await nats.connect(
+            "ws://localhost:8080",
+            ws_connection_headers=custom_headers,
+            reconnected_cb=reconnected_cb,
+            max_reconnect_attempts=5
+        )
+
+        # Create subscription
+        messages_received = []
+
+        async def message_handler(msg):
+            messages_received.append(msg.data)
+
+        await nc.subscribe("reconnect.test", cb=message_handler)
+
+        # Publish before reconnect
+        await nc.publish("reconnect.test", b"Before reconnect")
+        await nc.flush()
+
+        # Simulate server restart
+        await asyncio.get_running_loop().run_in_executor(
+            None, self.server_pool[0].stop
+        )
+        await asyncio.sleep(1)
+        await asyncio.get_running_loop().run_in_executor(
+            None, self.server_pool[0].start
+        )
+
+        # Wait for reconnection
+        await asyncio.wait_for(reconnected, timeout=5.0)
+
+        # Publish after reconnect
+        await nc.publish("reconnect.test", b"After reconnect")
+        await nc.flush()
+
+        # Wait a bit for message delivery
+        await asyncio.sleep(0.5)
+
+        # Verify we got messages
+        assert b"Before reconnect" in messages_received
+        assert b"After reconnect" in messages_received
+        assert reconnect_count > 0
+
+        await nc.close()
+
 
 class WebSocketTLSTest(SingleWebSocketTLSServerTestCase):
 
@@ -309,6 +417,34 @@ class WebSocketTLSTest(SingleWebSocketTLSServerTestCase):
         await asyncio.sleep(1)
 
         # Should not fail closing while disconnected.
+        await nc.close()
+
+    @async_test
+    async def test_ws_headers_with_tls(self):
+        """Test custom headers with TLS WebSocket connection"""
+        if not aiohttp_installed:
+            pytest.skip("aiohttp not installed")
+
+        # Note: This would require a TLS-enabled test server
+        # Keeping structure similar to the non-TLS test
+        custom_headers = {
+            "Authorization": ["Bearer SecureToken"],
+            "X-TLS-Client": ["secure-client-v1"]
+        }
+
+        nc = await nats.connect(
+            "wss://localhost:8081",
+            ws_connection_headers=custom_headers,
+            tls=self.ssl_ctx
+        )
+
+        # Basic functionality test
+        sub = await nc.subscribe("tls.test")
+        await nc.publish("tls.test", b"TLS test message")
+
+        msg = await sub.next_msg(timeout=1.0)
+        assert msg.data == b"TLS test message"
+
         await nc.close()
 
 

--- a/tests/test_custom_headers_websocket.py
+++ b/tests/test_custom_headers_websocket.py
@@ -83,6 +83,7 @@ class TestHeaderCatcher(unittest.TestCase):
             "X-Multi": ["v1", "v2"],  # repeated header -> comma-joined
             "Accept": ["application/json", "text/plain; q=0.8"],
             "X-Feature-Flags": ["feature-a", "feature-b", "feature-c"],
+            "Single-Header-Key": "Single-Header-Value"
         }
 
         try:
@@ -108,3 +109,4 @@ class TestHeaderCatcher(unittest.TestCase):
         self.assertTrue(has_header_value(headers, "X-Feature-Flags", "feature-a"))
         self.assertTrue(has_header_value(headers, "X-Feature-Flags", "feature-b"))
         self.assertTrue(has_header_value(headers, "X-Feature-Flags", "feature-c"))
+        self.assertTrue(has_header_value(headers, "Single-Header-Key", "Single-Header-Value"))

--- a/tests/test_custom_headers_websocket.py
+++ b/tests/test_custom_headers_websocket.py
@@ -1,0 +1,110 @@
+import asyncio
+import socket
+import threading
+import queue
+import unittest
+
+import pytest
+import nats
+from tests.utils import async_test
+
+try:
+    import aiohttp  # required by nats ws transport
+    aiohttp_installed = True
+except ModuleNotFoundError:
+    aiohttp_installed = False
+
+
+def start_header_catcher():
+    """
+    Minimal TCP listener that captures the incoming HTTP request lines
+    (WebSocket handshake) and returns them via a Queue.
+    """
+    q = queue.Queue(maxsize=1)
+    ln = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    ln.bind(("127.0.0.1", 0))
+    ln.listen(1)
+    host, port = ln.getsockname()
+
+    def _accept_once():
+        try:
+            conn, _ = ln.accept()
+            with conn:
+                conn.settimeout(2.0)
+                buf = b""
+                while b"\r\n\r\n" not in buf:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    buf += chunk
+                header_block = buf.split(b"\r\n\r\n", 1)[0]
+                lines = header_block.decode("latin1", errors="replace").split("\r\n")
+                q.put(lines)
+        except Exception:
+            q.put([])
+        finally:
+            try:
+                ln.close()
+            except OSError:
+                pass
+
+    threading.Thread(target=_accept_once, daemon=True).start()
+    return f"{host}:{port}", q, (lambda: ln.close())
+
+
+def has_header_value(headers, name, want):
+    prefix = name.lower() + ":"
+    for h in headers:
+        if ":" not in h:
+            continue
+        if not h.lower().startswith(prefix):
+            continue
+        val = h.split(":", 1)[1].strip()
+        for part in val.split(","):
+            if part.strip().lower() == want.lower():
+                return True
+    return False
+
+
+class TestHeaderCatcher(unittest.TestCase):
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+
+    @async_test
+    async def test_ws_headers_static_applied_on_handshake(self):
+        if not aiohttp_installed:
+            pytest.skip("aiohttp not installed")
+
+        addr, got, close_ln = start_header_catcher()
+
+        custom_headers = {
+            "Authorization": ["Bearer Random Token"],
+            "X-Multi": ["v1", "v2"],  # repeated header -> comma-joined
+            "Accept": ["application/json", "text/plain; q=0.8"],
+            "X-Feature-Flags": ["feature-a", "feature-b", "feature-c"],
+        }
+
+        try:
+            # Connect to our catcher; it won't complete the upgrade.
+            with self.assertRaises(Exception):
+                await asyncio.wait_for(
+                    nats.connect(
+                        f"ws://{addr}",
+                        ws_connection_headers=custom_headers,
+                        allow_reconnect=False,
+                    ),
+                    timeout=1.0,
+                )
+        finally:
+            headers = got.get(timeout=2.0)
+            close_ln()
+
+        self.assertTrue(has_header_value(headers, "Authorization", "Bearer Random Token"))
+        self.assertTrue(has_header_value(headers, "X-Multi", "v1"))
+        self.assertTrue(has_header_value(headers, "X-Multi", "v2"))
+        self.assertTrue(has_header_value(headers, "Accept", "application/json"))
+        self.assertTrue(has_header_value(headers, "Accept", "text/plain; q=0.8"))
+        self.assertTrue(has_header_value(headers, "X-Feature-Flags", "feature-a"))
+        self.assertTrue(has_header_value(headers, "X-Feature-Flags", "feature-b"))
+        self.assertTrue(has_header_value(headers, "X-Feature-Flags", "feature-c"))


### PR DESCRIPTION
This pull request introduces support for custom headers in WebSocket connections to the NATS server. The key changes include:

Provision for supplying custom WebSocket request headers — developers can now attach additional headers (e.g., authorization tokens or tracing metadata) when establishing a WebSocket connection via NATS py.

A reference to a related issue in the .NET client repository (https://github.com/nats-io/nats.net/issues/305) highlights the broader context and motivation for this enhancement